### PR TITLE
Issues/7130 transformationexception chain

### DIFF
--- a/src/main/java/io/gravitee/policy/jws/JWSPolicy.java
+++ b/src/main/java/io/gravitee/policy/jws/JWSPolicy.java
@@ -104,6 +104,7 @@ public class JWSPolicy {
     public ReadWriteStream onRequestContent(Request request, ExecutionContext executionContext, PolicyChain policyChain) {
         return TransformableRequestStreamBuilder
             .on(request)
+            .chain(policyChain)
             .contentType(MediaType.APPLICATION_JSON)
             .transform(map(executionContext, policyChain))
             .build();

--- a/src/test/java/io/gravitee/policy/jws/JWSPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jws/JWSPolicyTest.java
@@ -245,7 +245,8 @@ public class JWSPolicyTest {
         X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(
             new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8))
         );
-        jwsPolicy.validateCRLSFromCertificate(cert, new BigInteger("17521746654160821224073118409816269840"));
+        // WARNING: this test is based on real certificate from Wikipedia. Depending on the state of the expired certificates entries, it could be broken.
+        jwsPolicy.validateCRLSFromCertificate(cert, new BigInteger("18135611436097276018781887707242686781"));
     }
 
     private void shouldTransformInput_validX5CHeader_withPemFile(String pemFile) throws Exception {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7130

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.2-SNAPSHOT.issues-7130-transformationexception-chain`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jws/1.3.2-SNAPSHOT.issues-7130-transformationexception-chain/gravitee-policy-jws-1.3.2-SNAPSHOT.issues-7130-transformationexception-chain.zip)
  <!-- Version placeholder end -->
