### PR TITLE
fix(deps): update bcprov-jdk15on to bcprov-jdk18on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.3.0</gravitee-common.version>
         <jjwt.version>0.9.1</jjwt.version>
-        <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
+        <bcprov-jdk18on.version>1.77</bcprov-jdk18on.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
 
@@ -109,8 +109,8 @@
         <!-- Bouncycastle dependencies -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bcprov-jdk15on.version}</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bcprov-jdk18on.version}</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4028

**Description**

The library https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on has been moved to https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on

**Additional context**

The main goal of this task is to update the library and resolve vulnerability issues: 
https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6084022
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.1-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jws/1.6.1-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT/gravitee-policy-jws-1.6.1-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT.zip)
  <!-- Version placeholder end -->
